### PR TITLE
AJDA-1919: Update Snowflake drivers to ODBC 3.10.0 and SnowSQL 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:8.3-cli-bullseye
+FROM php:8.3-cli-trixie
 
-ARG SNOWFLAKE_ODBC_VERSION=2.25.12
-ARG SNOWFLAKE_SNOWSQL_VERSION=1.3.0
-ARG SNOWFLAKE_GPG_KEY=630D9F3CAB551AF3
+ARG SNOWFLAKE_ODBC_VERSION=3.10.0
+ARG SNOWFLAKE_SNOWSQL_VERSION=1.4.0
+ARG SNOWFLAKE_GPG_KEY=2A3149C82551A34A
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
 ENV COMPOSER_ALLOW_SUPERUSER 1
@@ -53,9 +53,9 @@ RUN set -ex; \
 #snoflake download + verify package
 COPY docker/driver/snowflake-policy.pol /etc/debsig/policies/$SNOWFLAKE_GPG_KEY/generic.pol
 COPY docker/driver/simba.snowflake.ini /usr/lib/snowflake/odbc/lib/simba.snowflake.ini
-ADD https://sfc-repo.azure.snowflakecomputing.com/odbc/linux/$SNOWFLAKE_ODBC_VERSION/snowflake-odbc-$SNOWFLAKE_ODBC_VERSION.x86_64.deb /tmp/snowflake-odbc.deb
-ADD https://sfc-repo.azure.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_x86_64/snowsql-$SNOWFLAKE_SNOWSQL_VERSION-linux_x86_64.bash /usr/bin/snowsql-linux_x86_64.bash
-ADD https://sfc-repo.azure.snowflakecomputing.com/snowsql/bootstrap/1.3/linux_x86_64/snowsql-$SNOWFLAKE_SNOWSQL_VERSION-linux_x86_64.bash.sig /tmp/snowsql-linux_x86_64.bash.sig
+ADD https://sfc-repo.snowflakecomputing.com/odbc/linux/$SNOWFLAKE_ODBC_VERSION/snowflake-odbc-$SNOWFLAKE_ODBC_VERSION.x86_64.deb /tmp/snowflake-odbc.deb
+ADD https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.4/linux_x86_64/snowsql-$SNOWFLAKE_SNOWSQL_VERSION-linux_x86_64.bash /usr/bin/snowsql-linux_x86_64.bash
+ADD https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.4/linux_x86_64/snowsql-$SNOWFLAKE_SNOWSQL_VERSION-linux_x86_64.bash.sig /tmp/snowsql-linux_x86_64.bash.sig
 
 # snowflake - charset settings
 ENV LANG en_US.UTF-8
@@ -77,6 +77,19 @@ RUN mkdir -p ~/.gnupg \
     && dpkg -i /tmp/snowflake-odbc.deb \
     && SNOWSQL_DEST=/usr/bin SNOWSQL_LOGIN_SHELL=~/.profile bash /usr/bin/snowsql-linux_x86_64.bash \
     && rm /tmp/snowflake-odbc.deb
+
+RUN cat <<EOF > /etc/odbcinst.ini
+[ODBC Drivers]
+SnowflakeDSIIDriver=Installed
+
+[SnowflakeDSIIDriver]
+APILevel=1
+ConnectFunctions=YYY
+Description=Snowflake DSII
+Driver=/usr/lib/snowflake/odbc/lib/libSnowflake.so
+DriverODBCVer=${SNOWFLAKE_ODBC_VERSION}
+SQLLevel=1
+EOF
 
 ## Composer - deps always cached unless changed
 # First copy only composer files

--- a/docker/driver/snowflake-policy.pol
+++ b/docker/driver/snowflake-policy.pol
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <!DOCTYPE Policy SYSTEM "http://www.debian.org/debsig/1.0/policy.dtd">
 <Policy xmlns="https://www.debian.org/debsig/1.0/">
-    <Origin Name="Snowflake Computing" id="630D9F3CAB551AF3" Description="Snowflake ODBC Driver DEB package"/>
+    <Origin Name="Snowflake Computing" id="2A3149C82551A34A" Description="Snowflake ODBC Driver DEB package"/>
     <Selection>
-        <Required Type="origin" File="debsig.gpg" id="630D9F3CAB551AF3"/>
+        <Required Type="origin" File="debsig.gpg" id="2A3149C82551A34A"/>
     </Selection>
     <Verification MinOptional="0">
-        <Required Type="origin" File="debsig.gpg" id="630D9F3CAB551AF3"/>
+        <Required Type="origin" File="debsig.gpg" id="2A3149C82551A34A"/>
     </Verification>
 </Policy>


### PR DESCRIPTION
# AJDA-1919: Update Snowflake drivers to ODBC 3.10.0 and SnowSQL 1.4.0

## Summary
This PR modernizes Snowflake connectivity by upgrading the ODBC driver from 2.25.12 to 3.10.0, SnowSQL from 1.3.0 to 1.4.0, and the base Docker image from Debian Bullseye to Trixie. The changes align with the implementation in `keboola/connection` repo which already uses these versions.

**Key changes:**
- Base image: `php:8.3-cli-bullseye` → `php:8.3-cli-trixie`
- ODBC driver: 2.25.12 → 3.10.0
- SnowSQL: 1.3.0 → 1.4.0
- GPG key: `630D9F3CAB551AF3` → `2A3149C82551A34A`
- Repository URLs: removed `azure` subdomain (now `sfc-repo.snowflakecomputing.com`)
- Added `/etc/odbcinst.ini` configuration for proper ODBC driver registration
- Updated `snowflake-policy.pol` with new GPG key

### Notes
- Docker build verified locally and succeeds
- Lint checks (phpcs, phpstan) pass
- All download URLs verified as accessible
- Changes based on reference implementation in `keboola/connection` repo which already uses ODBC 3.10.0 with Debian Trixie
- **This is a major version jump (ODBC 2.x → 3.x)** - potential for breaking changes exists despite successful build

---

**Link to Devin run:** https://app.devin.ai/sessions/a34d7a1fa086495fa8ab0bb25d089848  
**Requested by:** Ondřej Jodas (ondrej.jodas@keboola.com) / @ondrajodas