### PR TITLE
ci: drop Snowflake password auth (DMD-873)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,6 @@ env:
   SNOWFLAKE_DB_HOST: "kebooladev.snowflakecomputing.com"
   SNOWFLAKE_DB_WAREHOUSE: "DEV"
   SNOWFLAKE_DB_USER: "telemetry_data_gh_actions"
-  SNOWFLAKE_DB_PASSWORD: ${{ secrets.SNOWFLAKE_DB_PASSWORD }}
   SNOWFLAKE_DB_PRIVATE_KEY: ${{ secrets.SNOWFLAKE_DB_PRIVATE_KEY }}
   SNOWFLAKE_DB_PORT: "443"
   SNOWFLAKE_DB_SCHEMA: "telemetry_data_gh_actions"
@@ -100,7 +99,6 @@ jobs:
           docker run \
           -e SNOWFLAKE_DB_HOST \
           -e SNOWFLAKE_DB_USER \
-          -e SNOWFLAKE_DB_PASSWORD \
           -e SNOWFLAKE_DB_PRIVATE_KEY \
           -e SNOWFLAKE_DB_DATABASE \
           -e SNOWFLAKE_DB_PORT \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       "port": 3306,
       "user": "XXX",
       "database": "XXX",
-      "#password": "xxx"
+      "#privateKey": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       - SNOWFLAKE_DB_HOST
       - SNOWFLAKE_DB_USER
-      - SNOWFLAKE_DB_PASSWORD
       - SNOWFLAKE_DB_PRIVATE_KEY
       - SNOWFLAKE_DB_DATABASE
       - SNOWFLAKE_DB_PORT

--- a/src/Config.php
+++ b/src/Config.php
@@ -67,12 +67,6 @@ class Config extends BaseConfig
         return $imageParameters['db']['user'];
     }
 
-    public function getDbPassword(): ?string
-    {
-        $imageParameters = $this->getImageParameters();
-        return $imageParameters['db']['#password'] ?? null;
-    }
-
     public function getPrivateKey(): ?string
     {
         $imageParameters = $this->getImageParameters();

--- a/src/DbConnector.php
+++ b/src/DbConnector.php
@@ -30,31 +30,20 @@ class DbConnector
     private function createConnection(): Connection
     {
         try {
-            if ($this->config->getPrivateKey()) {
-                $connection = SnowflakeConnectionFactory::getConnectionWithCert(
-                    $this->config->getDbHost(),
-                    $this->config->getDbUser(),
-                    $this->config->getPrivateKey(),
-                    [
-                        'port' => $this->config->getDbPort(),
-                        'warehouse' => $this->config->getDbWarehouse(),
-                        'database' => $this->config->getDbDatabase(),
-                    ],
-                );
-            } elseif ($this->config->getDbPassword()) {
-                $connection = SnowflakeConnectionFactory::getConnection(
-                    $this->config->getDbHost(),
-                    $this->config->getDbUser(),
-                    $this->config->getDbPassword(),
-                    [
-                        'port' => $this->config->getDbPort(),
-                        'warehouse' => $this->config->getDbWarehouse(),
-                        'database' => $this->config->getDbDatabase(),
-                    ],
-                );
-            } else {
-                throw new UserException('Either "dbPassword" or "privateKeyPath" must be set.');
+            if (!$this->config->getPrivateKey()) {
+                throw new UserException('"privateKey" must be set.');
             }
+
+            $connection = SnowflakeConnectionFactory::getConnectionWithCert(
+                $this->config->getDbHost(),
+                $this->config->getDbUser(),
+                $this->config->getPrivateKey(),
+                [
+                    'port' => $this->config->getDbPort(),
+                    'warehouse' => $this->config->getDbWarehouse(),
+                    'database' => $this->config->getDbDatabase(),
+                ],
+            );
 
             $connection->executeStatement(
                 sprintf(
@@ -180,8 +169,6 @@ class DbConnector
         $cliConfig[] = sprintf('username = "%s"', $this->config->getDbUser());
         if (!is_null($this->config->getPrivateKeyPath())) {
             $cliConfig[] = sprintf('private_key_path = "%s"', $this->config->getPrivateKeyPath());
-        } elseif ($this->config->getDbPassword()) {
-            $cliConfig[] = sprintf('password = "%s"', $this->config->getDbPassword());
         }
         $cliConfig[] = sprintf('dbname = "%s"', $this->config->getDbDatabase());
         $cliConfig[] = sprintf('warehousename = "%s"', $this->config->getDbWarehouse());

--- a/tests/functional/activitycenter_mode_correct_telemetry_data/source/data/config.json
+++ b/tests/functional/activitycenter_mode_correct_telemetry_data/source/data/config.json
@@ -8,7 +8,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/activitycenter_mode_correct_telemetry_data_native-types-manifest/source/data/config.json
+++ b/tests/functional/activitycenter_mode_correct_telemetry_data_native-types-manifest/source/data/config.json
@@ -8,7 +8,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/activitycenter_mode_incremental_fetching/source/data/config.json
+++ b/tests/functional/activitycenter_mode_incremental_fetching/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/activitycenter_mode_incremental_fetching_state/source/data/config.json
+++ b/tests/functional/activitycenter_mode_incremental_fetching_state/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/organization_mode_correct_telemetry_data/source/data/config.json
+++ b/tests/functional/organization_mode_correct_telemetry_data/source/data/config.json
@@ -8,7 +8,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/organization_mode_incremental_fetching/source/data/config.json
+++ b/tests/functional/organization_mode_incremental_fetching/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/organization_mode_incremental_fetching_state/source/data/config.json
+++ b/tests/functional/organization_mode_incremental_fetching_state/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/project_mode_correct_telemetry_data/source/data/config.json
+++ b/tests/functional/project_mode_correct_telemetry_data/source/data/config.json
@@ -8,7 +8,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/project_mode_download_selected_tables/source/data/config.json
+++ b/tests/functional/project_mode_download_selected_tables/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     },

--- a/tests/functional/project_mode_ignore_incremental_fetching/source/data/config.json
+++ b/tests/functional/project_mode_ignore_incremental_fetching/source/data/config.json
@@ -10,7 +10,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     },

--- a/tests/functional/project_mode_img_params_stack_id/source/data/config.json
+++ b/tests/functional/project_mode_img_params_stack_id/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/project_mode_incremental_fetching/source/data/config.json
+++ b/tests/functional/project_mode_incremental_fetching/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/project_mode_incremental_fetching_state/source/data/config.json
+++ b/tests/functional/project_mode_incremental_fetching_state/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/project_mode_incremental_fetching_write_old_state/source/data/config.json
+++ b/tests/functional/project_mode_incremental_fetching_write_old_state/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/set_primary_keys/source/data/config.json
+++ b/tests/functional/set_primary_keys/source/data/config.json
@@ -8,7 +8,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/skip_staging_table/source/data/config.json
+++ b/tests/functional/skip_staging_table/source/data/config.json
@@ -9,7 +9,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }

--- a/tests/functional/telemetry_data_empty_result/source/data/config.json
+++ b/tests/functional/telemetry_data_empty_result/source/data/config.json
@@ -8,7 +8,7 @@
       "port": "%env(int:SNOWFLAKE_DB_PORT)%",
       "user": "%env(string:SNOWFLAKE_DB_USER)%",
       "database": "%env(string:SNOWFLAKE_DB_DATABASE)%",
-      "#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%",
+      "#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%",
       "schema": "%env(string:SNOWFLAKE_DB_SCHEMA)%",
       "warehouse": "%env(string:SNOWFLAKE_DB_WAREHOUSE)%"
     }


### PR DESCRIPTION
## Summary

Snowflake is deprecating username/password authentication. This repo already has key-pair (`SNOWFLAKE_DB_PRIVATE_KEY`) auth wired end-to-end, so this PR removes the password code path entirely (DMD-873).

## Changes

- `.github/workflows/push.yml`: drop `SNOWFLAKE_DB_PASSWORD` env var + the `-e SNOWFLAKE_DB_PASSWORD` docker flag in the test job (keypair env kept intact).
- `docker-compose.yml`: drop `SNOWFLAKE_DB_PASSWORD` env passthrough.
- `src/Config.php`: remove `getDbPassword()`.
- `src/DbConnector.php`: simplify `createConnection()` to require a private key, drop password branch from snowsql config.
- `tests/functional/**/source/data/config.json` (17 fixtures): swap `"#password": "%env(string:SNOWFLAKE_DB_PASSWORD)%"` -> `"#privateKey": "%env(string:SNOWFLAKE_DB_PRIVATE_KEY)%"` so fixtures still authenticate.
- `README.md`: update example config to show `#privateKey` instead of `#password`.

## Test plan

- [ ] CI green on this branch (`tests` job hits Snowflake via private key)
- [ ] `tests-in-kbc` job runs the deployed configs successfully